### PR TITLE
docs(README): update the readme to remove stale information

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -20,10 +20,15 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         runs-on: ubuntu-latest
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@ed2356ad628626a6b3f5be6c3e0255c0454fcdb9 # stable
             - name: Install cargo-audit
               uses: taiki-e/install-action@86ec8296ca78c5cfba526854b020d4e58cf41e67 # v2.44.51
               with:

--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -19,6 +19,9 @@ env:
   COSIGN_RELEASE_VERSION: v2.2.4
   SYFT_VERSION: v1.7.0
   SOURCE_DATE_EPOCH: 0
+permissions:
+  contents: read
+
 jobs:
     docker-build-push:
         runs-on: ubuntu-latest
@@ -26,6 +29,11 @@ jobs:
           id-token: write
           packages: write
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Get Last Commit Date/Time for reproducible builds

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,11 @@ jobs:
         source_changed: ${{steps.changed_dirs.outputs.source}}
         book_changed: ${{steps.changed_dirs.outputs.book}}
       steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+          with:
+            egress-policy: audit
+
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - name: Check changed directories
           id: changed_dirs
@@ -72,16 +77,21 @@ jobs:
                     - rust: nightly
                       label: nightly
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master
               with:
                 toolchain: ${{matrix.rust}}
                 components: rustfmt, clippy
             - name: Install nightly Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@nightly
+              uses: dtolnay/rust-toolchain@83bdede770b06329615974cf8c786f845d824dfb # nightly
               with:
                 toolchain: nightly
                 components: rustfmt, clippy

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -15,10 +15,15 @@ jobs:
             image: xd009642/tarpaulin:develop-nightly@sha256:58dd13385f546ae4c9ba41150a70f3e5c3a5b33c4c95bbfa4e7d303fc0b4f572
             options: --security-opt seccomp=unconfined
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             # Nightly Rust is required for cargo llvm-cov --doc.
-            - uses: dtolnay/rust-toolchain@nightly
+            - uses: dtolnay/rust-toolchain@83bdede770b06329615974cf8c786f845d824dfb # nightly
               with:
                 components: llvm-tools-preview
             - uses: taiki-e/install-action@86ec8296ca78c5cfba526854b020d4e58cf41e67 # v2.44.51

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+---
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4

--- a/.github/workflows/deploy_mdbook.yaml
+++ b/.github/workflows/deploy_mdbook.yaml
@@ -19,10 +19,18 @@ env:
   GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT_GITHUB }}
   BRANCH: ${{ github.ref_name }}
 
+permissions:
+  contents: read
+
 jobs:
   build_book:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout the Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install mdbook
@@ -47,6 +55,11 @@ jobs:
     outputs:
       deployment_url: ${{ steps.output_deployment_url.outputs.deployment_url }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Decide Deployment Environment
         id: deployment_environment
         run: |

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -11,6 +11,9 @@ on:
             new-release-published:
                 description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
                 value: ${{ jobs.get-next-version.outputs.new-release-published }}
+permissions:
+  contents: read
+
 jobs:
     get-next-version:
         name: Get next release version
@@ -18,6 +21,11 @@ jobs:
         outputs:
             new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,11 @@ jobs:
                       target: x86_64-unknown-linux-musl
                       cross: false
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install tree
@@ -53,7 +58,7 @@ jobs:
               if: runner.os == 'Linux' && !matrix.build.cross
               run: sudo apt install musl-tools mingw-w64
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # master
               id: rust-toolchain
               with:
                 toolchain: stable
@@ -106,6 +111,11 @@ jobs:
             new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
             new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,6 +36,11 @@ jobs:
       # actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/shuttle_deploy.yaml
+++ b/.github/workflows/shuttle_deploy.yaml
@@ -13,8 +13,13 @@ jobs:
         name: Shuttle Deployment
         runs-on: ubuntu-latest
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-            - uses: shuttle-hq/deploy-action@main
+            - uses: shuttle-hq/deploy-action@a499e4ebcb4b486a0e34d9af9ee2f28e7ee16501 # main
               with:
                 deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}

--- a/.github/workflows/sonar_analysis.yaml
+++ b/.github/workflows/sonar_analysis.yaml
@@ -14,17 +14,28 @@ on:
       - main
       - next
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for SonarSource/sonarcloud-github-action to determine which PR to decorate
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@9f9bba2c7aaf7a55eac26abbac906c3021d211b2 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,3 +149,7 @@ repos:
       rev: v4.0.3
       hooks:
         - id: reuse
+    - repo: https://github.com/jumanjihouse/pre-commit-hooks
+      rev: 3.0.0
+      hooks:
+        - id: shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 
 # Use the official Rust image as the builder image
 # Use the 1.78 version of the Rust image since it's the MSRV (Minimum Supported Rust Version) for the aaprop project
-FROM rust:1.78.0 AS chef
+FROM rust:1.78.0@sha256:5907e96b0293eb53bcc8f09b4883d71449808af289862950ede9a0e3cca44ff5 AS chef
 
 # Install the `cargo-chef` tool
 RUN cargo install cargo-chef

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ This project is a small server app that provides a REST API to access the proper
 
 ## Build Status
 
-|       | Stable                                                                                                                                                           | Beta                                                                                                                                                         | Nightly                                                                                                                                                            | MSRV (1.78.0)                                                                                                                                                |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Linux | ![Ubuntu x Stable Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-stable.json) | ![Ubuntu x Beta Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-beta.json) | ![Ubuntu x Nightly Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-nightly.json) | ![Ubuntu x MSRV Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-msrv.json) |
+| Rust Version  | Build Status                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Stable        | ![Ubuntu x Stable Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-stable.json)   |
+| Beta          | ![Ubuntu x Beta Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-beta.json)       |
+| Nightly       | ![Ubuntu x Nightly Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-nightly.json) |
+| MSRV (1.78.0) | ![Ubuntu x MSRV Rust](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AliSajid/625c1d8a63a7cbb926f8828d97d850b1/raw/ubuntu-msrv.json)       |
 
 **Note: We have stopped testing builds on Windows and macos for expediency. We recommend you use the docker image should you need to run the project on these platforms.**
 
@@ -43,19 +46,15 @@ This project is a small server app that provides a REST API to access the proper
 
 Contributions to the project are welcome. Please see the [Contributing Guidelines](CONTRIBUTING.md) for more information.
 
-This project is Gitpod-enabled. You can use Gitpod to contribute to the project without having to install any dependencies on your local machine. You can click the button below to start a Gitpod workspace with a complete development environment.
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/AliSajid/aaprop)
-
 ## License
 
-This project is dual-licensed under the [MIT License](LICENSES/MIT.txt) and the [Apache License (Version 2.0)](LICENSES/Apache-2.0.txt). You may choose to use this project under either license, at your discretion. Other, insignificant files are under the [CC0 License](LICENSES/CC0-1.0.txt). Please see the [LICENSES](LICENSES) directory for more information.
+This project is dual-licensed under the [MIT License](LICENSES/MIT.txt) and the [Apache License (Version 2.0)](LICENSES/Apache-2.0.txt). You may choose to use this project under either license, at your discretion. Other, ancillary files are under the [CC0 License](LICENSES/CC0-1.0.txt) and are dedicated to the Public Domain. Please see the [LICENSES](LICENSES) directory for more information.
 
 This project is REUSE compliant. You can find more information about REUSE [here](https://reuse.software/).
 
 ## Code of Conduct
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 <!-- vale write-good.Passive = NO -->
 <!-- vale Google.Passive = NO -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: MIT
+-->
+
+# Security Policy
+
+## Supported Versions
+
+The canonical version for `aaprop` will be the one that is deployed to [`aaprop.shuttleapp.dev`](https://aaprop.shuttleapp.dev). We will also support the current major version of the application in terms of security patches and issues.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v2.x    | :white_check_mark: |
+| v1.x    | :x:                |
+| v0.x    | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover any security vulnerabilities or potential issues, please follow these steps to report them:
+
+1. **Do not publicly disclose** the vulnerability until a fix is available.
+2. Email `[security@imamiland.com](mailto:security@imamiland.com)` with details of the vulnerability, including:
+   - Steps to reproduce the issue.
+   - A detailed description of the security impact.
+   - Potential fixes or recommendations if available.
+3. You will receive an acknowledgment within **48 hours** of your report.
+
+Once the issue has been assessed, we will provide a timeline for a fix and release. Security patches will be backported to the most recent major releases.
+
+## Vulnerability Disclosure Timeline
+
+- We aim to resolve critical vulnerabilities within **7 days** of being reported.
+- Non-critical vulnerabilities will be handled during regular development cycles and addressed in future updates.


### PR DESCRIPTION
# Description

This change updates the README.md file to improve the presentation of build status information and clarify licensing details. The build status table has been reformatted for better readability, with Rust versions as row headers and a single column for build status. The license section now explicitly mentions that ancillary files are dedicated to the Public Domain under the CC0 License. Additionally, the Gitpod-related content has been removed, and the link to the Code of Conduct has been corrected.

Fixes # (issue)

## Change Type

- [x] Style (Non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Was This Tested?

- [x] Verified README.md renders correctly on GitHub
- [x] Checked all links in the updated README.md

**Test Configuration**:
* Operating System: Ubuntu 22.04
* Browser: Google Chrome 120.0.6099.109

# Checklist:

- [x] Code follows the project's style guidelines
- [x] Code has undergone self-review
- [x] Documentation updated to reflect changes
- [x] Changes do not generate new warnings