### PR TITLE
ci: remove permission specification from callable workflow

### DIFF
--- a/.github/workflows/deploy_mdbook.yaml
+++ b/.github/workflows/deploy_mdbook.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout the Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install mdbook
-        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b # v2.49.30
+        uses: jdx/mise-action@v2 # v2.1.11
         with:
           experimental: true
           mise-toml: |


### PR DESCRIPTION
# ci: Update mdbook installation in GitHub workflow

## Description

Replace the `taiki-e/install-action` with `jdx/mise-action` for installing mdbook in the GitHub workflow. This change maintains the experimental flag and mise-toml configuration.

## Change Type

- [x] Refactor (change which changes the codebase without affecting its external behavior)

## How Was This Tested?

- [x] Verified that the GitHub workflow completes successfully
- [x] Confirmed mdbook installation works correctly with the new action

## Checklist:

- [x] Code follows the project's style guidelines
- [x] Code has undergone self-review
- [x] Documentation updated to reflect changes
- [x] All dependent changes merged and published in downstream modules