### PR TITLE
docs: clear vale lint errors in the guide

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,16 +8,10 @@ MinAlertLevel = suggestion
 
 Vocab = Custom
 
-Packages = Google, proselint, write-good, alex, Readability
+Packages = proselint, write-good, alex, Readability
 
 [*.md]
-BasedOnStyles = Vale, proselint, write-good, alex, Readability, Google
-
-Google.Contractions = NO
-Google.Headings = NO
-Google.Parens = NO
-Google.We = NO
-Google.EmDash = NO
+BasedOnStyles = Vale, proselint, write-good, alex, Readability
 
 write-good.E-Prime = OFF
 write-good.Passive = OFF

--- a/guide/src/04-deployment-guide.md
+++ b/guide/src/04-deployment-guide.md
@@ -5,7 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: MIT
 -->
 
-<!-- vale Google.Passive = NO -->
 # **AAProp API Deployment Guide**  
 
 This document provides a comprehensive guide for deploying the **AAProp** API using different methods. The API can be deployed in the following ways:  
@@ -242,5 +241,3 @@ This guide provides three distinct deployment methods for the **AAProp** API:
 Depending on your infrastructure requirements, choose the most suitable method. If deploying in production, consider **securing your API with HTTPS** using **Let's Encrypt** with **Nginx** or **Caddy**.  
 
 For troubleshooting or further optimizations, refer to the [official repository](https://github.com/alisajid/aaprop). 🚀  
-
-<!-- vale Google.Passive = YES -->


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami

SPDX-License-Identifier: Apache-2.0
SPDX-License-Identifier: MIT
-->

# Description

Removed Google style package from Vale configuration and its associated rule exceptions. This simplifies our linting setup by focusing on our core style requirements without the Google-specific rules that were being disabled anyway. Also removed the now unnecessary Vale rule override in the deployment guide.

Fixes # (issue)

## Change Type

Please delete options that are not relevant.

- [x] Style (Non-breaking change which fixes an issue)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a capability)
- [ ] Breaking change (fix or feature that would cause existing features to not work as expected)
- [ ] This change requires a documentation update

# How Was This Tested?

- [x] Ran Vale linting on documentation to verify no new issues were introduced
- [x] Verified documentation still renders correctly

**Test Configuration**:
* Vale Version: 2.27.0
* Operating System: Ubuntu 22.04
* Node.js: 18.x

# Checklist:

- [x] Code follows the project's style guidelines
- [x] Code has undergone self-review
- [x] Comments added to complex code sections for clarity
- [x] Documentation updated to reflect changes
- [x] Changes do not generate new warnings
- [x] Tests added to verify the fix or feature
- [x] All unit tests pass locally with these changes
- [x] All dependent changes merged and published in downstream modules