### PR TITLE
ci: fix the input for the mise-action action

### DIFF
--- a/.github/workflows/deploy_mdbook.yaml
+++ b/.github/workflows/deploy_mdbook.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2
         with:
           experimental: true
-          mise-toml: |
+          mise_toml: |
             [tools]
             node = 22
             "npm:vercel" = "latest"

--- a/.github/workflows/deploy_mdbook.yaml
+++ b/.github/workflows/deploy_mdbook.yaml
@@ -37,8 +37,8 @@ jobs:
           experimental: true
           mise_toml: |
             [tools]
-            "cargo:mdbook" = 0.4.45
-            "cargo:mdbook-inline-highlighting" = 0.1.0
+            "cargo:mdbook" = "0.4.45"
+            "cargo:mdbook-inline-highlighting" = "0.1.0"
 
       - name: Build the Book
         run: mdbook build guide
@@ -87,7 +87,7 @@ jobs:
           experimental: true
           mise_toml: |
             [tools]
-            node = 22
+            node = "22"
             "npm:vercel" = "latest"
 
       - name: Populate Vercel Variables


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami

SPDX-License-Identifier: Apache-2.0
SPDX-License-Identifier: MIT
-->

# Description

Fixed a parameter name in the GitHub workflow for deploying mdbook. Changed `mise-toml` to `mise_toml` in the mise-action configuration to ensure proper parsing of the configuration.

Fixes # (issue)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

# How Was This Tested?

- [x] Verified that the GitHub workflow runs successfully with the corrected parameter name

**Test Configuration**:
* GitHub Actions Runner
* Operating System: Ubuntu Latest

# Checklist:

- [x] Code follows the project's style guidelines
- [x] Code has undergone self-review
- [x] Documentation updated to reflect changes
- [x] Changes do not generate new warnings